### PR TITLE
docs: typo fix for stopping testnets

### DIFF
--- a/testnet/install/linux-ubuntu.md
+++ b/testnet/install/linux-ubuntu.md
@@ -95,7 +95,7 @@ bash ./scripts/local_testnet/start_local_testnet.sh
 
 To stop
 ```
-bash ./scripts/local_testnet/start_local_testnet.sh
+bash ./scripts/local_testnet/stop_local_testnet.sh
 ```
 
 To test the private test network (replace the MAPPED_PORT in the following with port that is mapped to 8545 that you see after running previous step which is Step 2. Start the private test network).

--- a/testnet/install/mac.md
+++ b/testnet/install/mac.md
@@ -57,7 +57,7 @@ bash ./scripts/local_testnet/start_local_testnet.sh
 To stop
 
 ```bash
-bash ./scripts/local_testnet/start_local_testnet.sh
+bash ./scripts/local_testnet/stop_local_testnet.sh
 ```
 
 To test the private test network (replace the MAPPED_PORT in the following with port that is mapped to 8545 that you see after running previous step which is Step 2. Start the private test network).

--- a/testnet/install/windows.md
+++ b/testnet/install/windows.md
@@ -119,7 +119,7 @@ bash ./scripts/local_testnet/start_local_testnet.sh
 
 To stop
 ```
-bash ./scripts/local_testnet/start_local_testnet.sh
+bash ./scripts/local_testnet/stop_local_testnet.sh
 ```
 
 To test the private test network (replace the MAPPED_PORT in the following with port that is mapped to 8545 that you see after running previous step which is Step 2. Start the private test network).


### PR DESCRIPTION
This pull request includes changes to the documentation for stopping the local test network across different operating systems. The changes ensure that the correct script is referenced for stopping the network.

Documentation updates:

* [`testnet/install/linux-ubuntu.md`](diffhunk://#diff-4e57604a3ed9088f9573061e39cb65f82b5b9dcc48f8fa8519c0d137686ddb7aL98-R98): Updated the command to stop the local test network to use `stop_local_testnet.sh` instead of `start_local_testnet.sh`.
* [`testnet/install/mac.md`](diffhunk://#diff-1499048e96d69118fb87049ffeda3da24be9aa9fb5e839b1e4dc3c645370fea7L60-R60): Corrected the stop command to use `stop_local_testnet.sh` instead of `start_local_testnet.sh`.
* [`testnet/install/windows.md`](diffhunk://#diff-87fa4fdfa875756dfbaa5482e08f906726f9a9de2d11c622ef383e114df2cd74L122-R122): Fixed the stop command to reference `stop_local_testnet.sh` instead of `start_local_testnet.sh`.