### PR TITLE
docs: consistent bazel versions across archs, brew and shell minor improvements

### DIFF
--- a/testnet/install/linux-ubuntu.md
+++ b/testnet/install/linux-ubuntu.md
@@ -58,7 +58,7 @@ And update the docker.sock user group
 sudo chown root:docker /var/run/docker.sock
 ```
 
-### Install Bazel v6.3.2 (Instructions taken from https://bazel.build/install/ubuntu)
+### Install Bazel v7.5.0 (Instructions taken from https://bazel.build/versions/7.5.0/install/ubuntu)
 
 ```
 sudo apt install apt-transport-https curl gnupg -y
@@ -66,7 +66,7 @@ curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-arch
 sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 sudo apt update
-sudo apt-get install bazel-6.3.2
+sudo apt-get install bazel-7.5.0
 ```
 
 ### Install Kurtosis 
@@ -101,7 +101,7 @@ bash ./scripts/local_testnet/stop_local_testnet.sh
 To test the private test network (replace the MAPPED_PORT in the following with port that is mapped to 8545 that you see after running previous step which is Step 2. Start the private test network).
 
 ```
-curl http://127.0.0.1:MAPPED_PORT/   -X POST   -H "Content-Type: application/json"   --data '{"method":"zond_getBlockByNumber","params":["latest", false],"id":1,"jsonrpc":"2.0"}' | jq -e
+curl http://127.0.0.1:MAPPED_PORT/ -X POST -H "Content-Type: application/json" --data '{"method":"zond_getBlockByNumber","params":["latest", false],"id":1,"jsonrpc":"2.0"}' | jq -e
 ```
 
 :::info PRO-Tip:

--- a/testnet/install/mac.md
+++ b/testnet/install/mac.md
@@ -18,18 +18,22 @@ Tested on MacOS Sequoia Version 15.3.1 (Apple Silicon)
 
 Getting started with the Zond testnet Local system
 
-## 1. Install prerequisits 
+## 1. Install prerequisites 
 
-If you haven't done so already, install brew, then install [docker](https://docs.docker.com/desktop/setup/install/mac-install/) and other prerequesits with brew.
+If you haven't done so already, install brew, then install [docker](https://docs.docker.com/desktop/setup/install/mac-install/) and other prerequesites with brew.
 
 ```bash
 brew install bazel@7 kurtosis-tech/tap/kurtosis-cli jq yq
 ```
 
-Be sure to add bazel 7.5.0 to your path.
-
+Run this to make bazel 7 the default version (if other versions are installed)
 ```bash
-echo 'export PATH="/opt/homebrew/opt/bazel@7/bin:$PATH"' >> ~/.zshrc
+brew unlink bazel@8 && brew link --force bazel@7
+```
+
+Be sure to add bazel 7.5.0 to your default shell's path
+```bash
+echo 'export PATH="/opt/homebrew/opt/bazel@7/bin:$PATH"' >> ~/.${SHELL##*/}rc
 ```
 
 ## 2. Clone the repo & cd into it
@@ -63,7 +67,7 @@ bash ./scripts/local_testnet/stop_local_testnet.sh
 To test the private test network (replace the MAPPED_PORT in the following with port that is mapped to 8545 that you see after running previous step which is Step 2. Start the private test network).
 
 ```bash
-curl http://127.0.0.1:MAPPED_PORT/   -X POST   -H "Content-Type: application/json"   --data '{"method":"zond_getBlockByNumber","params":["latest", false],"id":1,"jsonrpc":"2.0"}' | jq -e
+curl http://127.0.0.1:MAPPED_PORT/ -X POST -H "Content-Type: application/json" --data '{"method":"zond_getBlockByNumber","params":["latest", false],"id":1,"jsonrpc":"2.0"}' | jq -e
 ```
 
 :::info Pro-tip: 

--- a/testnet/install/windows.md
+++ b/testnet/install/windows.md
@@ -13,7 +13,7 @@ description: "This page contains instructions for installing the Zond Testnet #B
 
 
 
-# Setting up prerequisits
+# Setting up prerequisites
 
 ## 1. Setting up WSL 
 
@@ -80,7 +80,7 @@ sudo chown root:docker /var/run/docker.sock
 sudo snap install yq
 ```
 
-### Install Bazel v6.3.2 (Instructions taken from https://bazel.build/install/ubuntu)
+### Install Bazel v7.5.0 (Instructions taken from https://bazel.build/versions/7.5.0/install/ubuntu)
 
 ```
 sudo apt install apt-transport-https curl gnupg -y
@@ -88,7 +88,7 @@ curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-arch
 sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 sudo apt update
-sudo apt-get install bazel-6.3.2
+sudo apt-get install bazel-7.5.0
 ```
 
 ### Install Kurtosis 


### PR DESCRIPTION
This pull request includes updates to the installation instructions for different operating systems, mainly focusing on updating Bazel to version 7.5.0, flexible shell path support for Bazel, setting Bazel 7.5.0 as default version if other versions were already installed.

Updates to installation instructions:

* [`testnet/install/linux-ubuntu.md`](diffhunk://#diff-4e57604a3ed9088f9573061e39cb65f82b5b9dcc48f8fa8519c0d137686ddb7aL61-R69): Updated Bazel installation instructions to version 7.5.0.
* [`testnet/install/mac.md`](diffhunk://#diff-1499048e96d69118fb87049ffeda3da24be9aa9fb5e839b1e4dc3c645370fea7L21-R36): Updated Bazel installation instructions to version 7.5.0, added a command to make Bazel 7 the default version, and fixed typographical errors.
* [`testnet/install/windows.md`](diffhunk://#diff-87fa4fdfa875756dfbaa5482e08f906726f9a9de2d11c622ef383e114df2cd74L16-R16): Updated Bazel installation instructions to version 7.5.0 and fixed typographical errors. [[1]](diffhunk://#diff-87fa4fdfa875756dfbaa5482e08f906726f9a9de2d11c622ef383e114df2cd74L16-R16) [[2]](diffhunk://#diff-87fa4fdfa875756dfbaa5482e08f906726f9a9de2d11c622ef383e114df2cd74L83-R91)